### PR TITLE
Ignore json code snippets

### DIFF
--- a/src/parse-code-snippets-from-markdown.js
+++ b/src/parse-code-snippets-from-markdown.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const isStartOfSnippet = line => line.trim().match(/```\W*(JavaScript|js|es6)/i);
+const isStartOfSnippet = line => line.trim().match(/```\W*(JavaScript|js|es6)\s?$/i);
 const isEndOfSnippet = line => line.trim() === '```';
 const isSkip = line => line.trim() === '<!-- skip-example -->';
 const isCodeSharedInFile = line => line.trim() === '<!-- share-code-between-examples -->';

--- a/test/markdown-doctest-test.js
+++ b/test/markdown-doctest-test.js
@@ -191,4 +191,19 @@ describe('runTests', () => {
     assert.equal(failingResults.length, 0);
     assert.equal(skippedResults.length, 0);
   });
+
+  it('ignores json examples', () => {
+    const files = [getTestFilePath('json.md')];
+    const config = {};
+
+    const results = doctest.runTests(files, config);
+
+    const passingResults = results.filter(result => result.status === 'pass');
+    const failingResults = results.filter(result => result.status === 'fail');
+    const skippedResults = results.filter(result => result.status === 'skip');
+
+    assert.equal(passingResults.length, 0);
+    assert.equal(failingResults.length, 0);
+    assert.equal(skippedResults.length, 0);
+  });
 });

--- a/test/test_files/json.md
+++ b/test/test_files/json.md
@@ -1,0 +1,10 @@
+
+Here is some json:
+
+```json
+{
+  test: 'post'
+}
+```
+
+Markdown-doctest is surely smart enough to ignore it.


### PR DESCRIPTION
Previously, markdown-doctest would incorrectly identify these snippets as JavaScript and attempt to run them.

/js/ matches /json/ but /js$/ doesn't.