### PR TITLE
Use commander as CLI Library and add --config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/core": "^7.6.4",
     "@babel/preset-env": "^7.6.3",
     "chalk": "^2.4.2",
+    "commander": "^4.0.1",
     "glob": "^7.1.4"
   },
   "babel": {

--- a/test/markdown-doctest.test.js
+++ b/test/markdown-doctest.test.js
@@ -18,7 +18,7 @@ describe('runTests', () => {
 
     const passingResults = results.filter(result => result.status === 'pass');
 
-    assert.equal(passingResults.length, 1);
+    assert.strictEqual(passingResults.length, 1);
   });
 
   it('fail', () => {
@@ -29,8 +29,8 @@ describe('runTests', () => {
     const passingResults = results.filter(result => result.status === 'pass');
     const failingResults = results.filter(result => result.status === 'fail');
 
-    assert.equal(passingResults.length, 1, JSON.stringify(results, null, 2));
-    assert.equal(failingResults.length, 2);
+    assert.strictEqual(passingResults.length, 1, JSON.stringify(results, null, 2));
+    assert.strictEqual(failingResults.length, 2);
   });
 
   it('skip', () => {
@@ -42,9 +42,9 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 1);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 1);
+    assert.strictEqual(passingResults.length, 1);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 1);
   });
 
   it('config', () => {
@@ -61,9 +61,9 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 1, results[0].stack);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 1, results[0].stack);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
   });
 
   it('globals', () => {
@@ -80,9 +80,9 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 1, results[0].stack);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 1, results[0].stack);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
   });
 
   it('es6', () => {
@@ -95,9 +95,9 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 2, results[0].stack);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 2, results[0].stack);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
   });
 
   it('joins tests', () => {
@@ -110,9 +110,9 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 3, results[1].stack);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 3, results[1].stack);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
   });
 
   it('supports regex imports', () => {
@@ -120,7 +120,7 @@ describe('runTests', () => {
     const config = {
       regexRequire: {
         'lo(.*)': function (fullPath, matchedName) {
-          assert.equal(matchedName, 'dash');
+          assert.strictEqual(matchedName, 'dash');
 
           return {
             range: () => []
@@ -135,16 +135,16 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 1, results[0].stack);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 1, results[0].stack);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
   });
 
   it('runs the beforeEach hook prior to each example', () => {
     const files = [getTestFilePath('before-each.md')];
     const a = {
       value: 0
-    }
+    };
 
     const config = {
       globals: {
@@ -160,11 +160,11 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 3, results[0].stack);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 3, results[0].stack);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
 
-    assert.equal(a.value, 1);
+    assert.strictEqual(a.value, 1);
   });
 
   it('ignores json examples', () => {
@@ -177,8 +177,8 @@ describe('runTests', () => {
     const failingResults = results.filter(result => result.status === 'fail');
     const skippedResults = results.filter(result => result.status === 'skip');
 
-    assert.equal(passingResults.length, 0);
-    assert.equal(failingResults.length, 0);
-    assert.equal(skippedResults.length, 0);
+    assert.strictEqual(passingResults.length, 0);
+    assert.strictEqual(failingResults.length, 0);
+    assert.strictEqual(skippedResults.length, 0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,6 +1316,11 @@ commander@2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+commander@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.0.1.tgz#b67622721785993182e807f4883633e6401ba53c"
+  integrity sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
Hi! This is the PR for #52 

I've made several changes:
1. You've used `assert.equals` in your tests which is [deprecated](https://nodejs.org/api/assert.html#assert_assert_equal_actual_expected_message) and has a stability of `0` in the latest nodejs release. I've changed it to [`assert.strictEqual`](https://nodejs.org/api/assert.html#assert_assert_strictequal_actual_expected_message).
2. In the [cmd.js](https://github.com/Simonwep/markdown-doctest/blob/454c99a4a965ada6effb23a0792bbf4d282fca8c/bin/cmd.js) file I've made several changes:
2.1 Replacing all `var` to `let` or `const` keywords since `var` is "deprecated" and mixing these isn't that good (I've updated most of the syntax to ES6 since the support isn't as bad as 4y ago).
2.2 I've added [commander.js](https://github.com/tj/commander.js) as dependencie to [simplify](https://github.com/Simonwep/markdown-doctest/blob/454c99a4a965ada6effb23a0792bbf4d282fca8c/bin/cmd.js#L25) the handling of commands.
2.3 I've made a [default config object](https://github.com/Simonwep/markdown-doctest/blob/454c99a4a965ada6effb23a0792bbf4d282fca8c/bin/cmd.js#L18) which can be extended by the command-line for maybe further extensions.
2.4 I've added the [`-c, --config`](https://github.com/Simonwep/markdown-doctest/blob/454c99a4a965ada6effb23a0792bbf4d282fca8c/bin/cmd.js#L30) option to specify a custom config path.
2.5 `commander.js` will automatically build a `help` screen which looks currently like this:
```
Usage: markdown-doctest [options]

Test all the code in your markdown docs!

Options:
  -v, --version        output the current version
  -c, --config <path>  custom config location (default: "G:\\<path-to-my-project>\\.markdown-doctest-setup.js")
  -h, --help           output usage informations

```

I've also added a [`-v, --version` option](https://github.com/Simonwep/markdown-doctest/blob/454c99a4a965ada6effb23a0792bbf4d282fca8c/bin/cmd.js#L28) to get the current version (maybe if someone uses it globally)

#### Further ideas:
Currently, if everything went fine, it outputs
```
...

Passed: 3

Success!
```

Maybe it'd be nice to print a table to give a overview which example passed and what need to be fixed:
```
/index.md           passed
/docs/boo.md        passed
/docs/sub/bam.md    passed
/docs/sub/foo.md    failed
/docs/sub/tam.md    passed

Passed: 4
Failed: 1

[print error message here]
```
